### PR TITLE
Make markdown-it work in production

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -9,5 +9,7 @@ requests==2.18.4
 urllib3==1.22
 
 # Markdown & LaTeX
-Naked==0.1.31
 pypandoc==1.4
+
+# misc
+bpython==0.16

--- a/src/tests/test_models.py
+++ b/src/tests/test_models.py
@@ -6,10 +6,19 @@ from mock import MagicMock
 
 # Some markdown text
 MD = '''# Title
-This is some **bold** text.
+Dies ist ein [Markdown](https://daringfireball.net/projects/markdown/)-Dokument mit der Möglichkeit, mathematische Ausdrücke einzugeben.
 
-$$ 5 + x = 5 $$
-'''
+Die Vorschau folgt der CommonMark-Spezifikation. Alle mathematischen Ausdrücke nutzen die LaTeX-Syntax.
+
+### Aufgabe 1
+Hier ist eine Gleichung:
+
+$$ 2 - x = 5 $$
+
+### Aufgabe 2
+Mathematische Ausdrücke wie $x=5$ können auch im Text stehen. Es geht aber auch komplizierter:
+
+$$ \\int_\{0\}^{\infty} dx x^2 = 99 $$'''
 
 
 class TestExerciseModel:
@@ -59,4 +68,4 @@ class TestExerciseModel:
         # THEN the `text_tex` model field is filled with LaTeX
         tex = '''\section{Title}'''
         assert ex.text_tex.startswith(tex)
-        assert '\[ 5 + x = 5 \]' in ex.text_tex
+        assert '\[ 2 - x = 5 \]' in ex.text_tex

--- a/src/um/exercises/models.py
+++ b/src/um/exercises/models.py
@@ -1,5 +1,6 @@
 """Exercise models."""
 import os
+import subprocess
 
 # https://docs.python.org/3.6/library/shlex.html#shlex.quote
 from shlex import quote
@@ -8,10 +9,15 @@ from django.db import models
 
 import pypandoc
 
-from Naked.toolshed.shell import muterun_js
-
+# get path to node script
 MODULE_DIR = os.path.dirname(os.path.abspath(__file__))
 script = os.path.join(MODULE_DIR, 'static/js/script.js')
+
+# get path to node binary
+node = os.path.expanduser('~/.nvm/versions/node/v6.11.2/bin/node')
+if not os.path.exists(node):
+    # if nvm is not used, use system binary (i.e. on Travis CI)
+    node = 'node'
 
 
 class Exercise(models.Model):
@@ -23,8 +29,11 @@ class Exercise(models.Model):
 
     def render_html(self) -> None:
         """Render the raw Markdown/LaTeX `text` into HTML."""
-        result = muterun_js(script, quote(self.text))
-        self.text_html = result.stdout.decode()
+        string = quote(self.text)
+        command = f'{node} {script} {string}'
+        result = subprocess.check_output(command, shell=True, stderr=subprocess.STDOUT)
+
+        self.text_html = result.decode()
 
     def render_tex(self) -> None:
         """Render the raw Markdown/LaTeX `text` into LaTeX code."""


### PR DESCRIPTION
Use subprocess instead of naked. And call node
binary directly.

If no nvm present, use system node binary

Improve render_html tests

try it with check_output

Output errors too

clean up code